### PR TITLE
[FEAT] 회원가입 url 인증필터 거치지 않도록 permitall 설정 + Swagger 문서 설명 추가

### DIFF
--- a/src/main/java/com/ajoufinder/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/ajoufinder/be/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable()) // Swagger로 테스트하려면 disable 필요
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/signup", "auth/login", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers("user/signup", "auth/login", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/ajoufinder/be/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ajoufinder/be/global/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.ajoufinder.be.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +14,11 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
+                .info(new Info()
+                        .title("AjouFinder API 명세서")                // ✅ 여기 변경
+                        .version("v1.0")
+                        .description("AjouFinder 서비스의 REST API 명세서입니다.")
+                )
                 .addSecurityItem(new SecurityRequirement().addList("sessionAuth"))
                 .components(new Components().addSecuritySchemes("sessionAuth",
                         new SecurityScheme()


### PR DESCRIPTION
회원가입 시 403에러가 뜨는 문제를 해결합니다. 
문제원인: 회원가입 api 가 인증 필터를 거치면서 access deny 됌.
문제해결: 인증필터 거치지 않도록 sequrityconfig의 permitall 설정에 /user/auth 경로 추가